### PR TITLE
MetroCUBEvania: Fix very incorrect medal classifications

### DIFF
--- a/worlds/MetroCUBEvania/progression.txt
+++ b/worlds/MetroCUBEvania/progression.txt
@@ -1,10 +1,10 @@
-starting medal: progression
-lava medal: filler
-ice medal: progression
-counterfeit medal: mcguffin
+starting medal: mcguffin
+lava medal: mcguffin
+ice medal: mcguffin
+counterfeit medal: filler
 springboards: progression
 key: progression
 dive: progression
 double jump: progression
 cage medal: mcguffin
-springboards medal: progression
+springboards medal: mcguffin


### PR DESCRIPTION
There is a yaml option that requires you to have all 5 medals to goal: starting medal, lava medal, ice medal, cage medal, and springboards medal. There are no checks behind the gate that requires all medals, so they are all macguffins. The counterfeit medal is a logically irrelevant filler item.