### PR TITLE
fix Trash Can logic

### DIFF
--- a/worlds/Stardew Valley/progression.txt
+++ b/worlds/Stardew Valley/progression.txt
@@ -51,7 +51,7 @@ Progressive Hoe: progression
 Progressive Pickaxe: progression
 Progressive Axe: progression
 Progressive Watering Can: progression
-Progressive Trash Can: filler
+Progressive Trash Can: progression
 Progressive Fishing Rod: progression
 Golden Scythe: unknown
 Progressive Mine Elevator: progression


### PR DESCRIPTION
Progressive Trash Can locks the Trash Can upgrade checks at Clint's.