### PR TITLE
Fully rework Aquaria

### DIFF
--- a/worlds/Aquaria/progression.txt
+++ b/worlds/Aquaria/progression.txt
@@ -1,222 +1,263 @@
 Anemone: filler
-Arnassi statue: unknown
-Big seed: filler
-Glowing seed: unknown
-Black pearl: filler
-Baby blaster: useful
-Crab armor: unknown
-Baby dumbo: unknown
-Tooth: filler
-Energy statue: unknown
-Krotite armor: unknown
-Golden starfish: unknown
-Golden gear: unknown
-Jelly beacon: unknown
-Jelly costume: unknown
-Jelly plant: unknown
-Mithalas doll: unknown
-Mithalan dress: filler
-Mithalas banner: unknown
-Mithalas pot: unknown
-Mutant costume: filler
-Baby nautilus: unknown
-Baby piranha: unknown
-Arnassi Armor: progression
-Seed bag: filler
-King's Skull: filler
-Song plant spore: unknown
-Stone head: unknown
-Sun key: unknown
-Girl costume: filler
-Odd container: unknown
-Trident: filler
-Turtle egg: unknown
-Jelly egg: unknown
-Urchin costume: useful
-Baby walker: unknown
-Vedha's Cure-All-All: useful
-Zuuna's perogi: useful
 Arcane poultice: useful
+Arcane Poultice: useful
+Arnassi Armor: progression
+Arnassi Statue: filler
+Arnassi statue: filler
+Baby blaster: useful
+Baby Blaster: progression
+Baby Dumbo: progression
+Baby dumbo: progression
+Baby nautilus: useful
+Baby Nautilus: progression
+Baby piranha: useful
+Baby Piranha: progression
+Baby Walker: filler
+Baby walker: filler
+Beast form: progression
+Beast Form: progression
+Berry Ice Cream: useful
 Berry ice cream: useful
+Big seed: filler
+Big Seed: filler
+Bind song: progression
+Bind Song: progression
+Black pearl: filler
+Black Pearl: filler
 Buttery sea loaf: useful
+Buttery Sea Loaf: useful
+Cold Borscht: useful
 Cold borscht: useful
 Cold soup: useful
+Cold Soup: useful
+Crab armor: useful
+Crab Armor: useful
 Crab cake: useful
+Crab Cake: useful
 Divine soup: useful
+Divine Soup: useful
+Door to the Cathedral opened: progression
+Dual form: progression
+Dual form: progression
 Dumbo ice cream: useful
+Dumbo Ice Cream: useful
+Eel Oil x 2: useful
+Eel oil x 2: useful
+Energy form: progression
+Energy Form: progression
+Energy Statue: filler
+Energy statue: filler
+Fish form: progression
+Fish Form: progression
+Fish Meat x 2: useful
+Fish meat x 2: useful
+Fish Oil x 3: useful
+Fish oil x 3: useful
+Fish Oil: useful
 Fish oil: useful
+Girl costume: filler
+Girl Costume: filler
+Glowing Egg x 2: useful
+Glowing egg x 2: useful
+Glowing Egg: useful
 Glowing egg: useful
+Glowing Seed: filler
+Glowing seed: filler
+Golden Gear: filler
+Golden gear: filler
+Golden Starfish: filler
+Golden starfish: filler
+Hand Roll: useful
 Hand roll: useful
+Healing Poultice x 2: useful
+Healing poultice x 2: useful
+Healing Poultice: useful
 Healing poultice: useful
+Health Upgrade: useful
+Health upgrade: useful
+Hearty Soup: useful
 Hearty soup: useful
 Hot borscht: useful
+Hot Borscht: useful
+Hot soup x 2: progression
+Hot Soup x 2: progression
 Hot soup: progression
+Hot Soup: progression
 Ice cream: useful
+Ice Cream: useful
+Jelly Beacon: filler
+Jelly beacon: filler
+Jelly costume: useful
+Jelly Costume: useful
+Jelly Egg: filler
+Jelly egg: filler
+Jelly Plant: filler
+Jelly plant: filler
+King's Skull: filler
+Krotite Armor: filler
+Krotite armor: filler
+Leadership Roll x 2: useful
+Leadership roll x 2: useful
+Leadership Roll: useful
 Leadership roll: useful
+Leaf poultice x 3: progression
+Leaf Poultice x 3: progression
 Leaf poultice: progression
+Leaf Poultice: progression
+Leeching Poultice: useful
 Leeching poultice: useful
 Legendary cake: useful
+Legendary Cake: useful
+Li and Li song: progression
+Li and Li Song: progression
 Loaf of life: useful
+Loaf of Life: useful
+Long Life Soup: useful
 Long life soup: useful
 Magic soup: useful
-Mushroom x 2: useful
-Perogi: useful
-Plant leaf: useful
-Plump perogi: useful
-Poison loaf: filler
-Poison soup: filler
-Rainbow mushroom: useful
-Rainbow soup: useful
-Red berry: useful
-Red bulb x 2: useful
-Rotten cake: filler
-Rotten loaf x 8: filler
-Rotten meat: filler
-Royal soup: useful
-Sea cake: useful
-Sea loaf: filler
-Shark fin soup: useful
-Sight poultice: useful
-Small bone x 2: useful
-Small egg: useful
-Small tentacle x 2: useful
-Special bulb: useful
-Special cake: useful
-Spicy meat x 2: useful
-Spicy roll: useful
-Spicy soup: useful
-Spider roll: useful
-Swamp cake: useful
-Tasty cake: useful
-Tasty roll: useful
-Tough cake: useful
-Turtle soup: useful
-Vedha sea crisp: useful
-Veggie cake: useful
-Veggie ice cream: useful
-Veggie soup: useful
-Volcano roll: useful
-Health upgrade: useful
-Wok: useful
-Eel oil x 2: useful
-Fish meat x 2: useful
-Fish oil x 3: useful
-Glowing egg x 2: useful
-Healing poultice x 2: useful
-Hot soup x 2: progression
-Leadership roll x 2: useful
-Leaf poultice x 3: progression
-Plant leaf x 2: useful
-Plant leaf x 3: useful
-Rotten meat x 2: filler
-Rotten meat x 8: filler
-Sea loaf x 2: filler
-Small bone x 3: useful
-Small egg x 2: useful
-Li and Li song: progression
-Shield song: useful
-Beast form: progression
-Sun form: progression
-Nature form: progression
-Energy form: progression
-Bind song: progression
-Fish form: progression
-Spirit form: progression
-Dual form: progression
-Transturtle Veil top left: progression
-Transturtle Veil top right: progression
-Transturtle Open Water top right: progression
-Transturtle Forest bottom left: progression
-Transturtle Home water: unknown
-Transturtle Abyss right: progression
-Transturtle Final Boss: progression
-Transturtle Simon says: unknown
-Transturtle Arnassi ruins: unknown
-Arnassi Statue: filler
-Big Seed: filler
-Glowing Seed: filler
-Black Pearl: filler
-Baby Blaster: useful
-Crab Armor: useful
-Baby Dumbo: progression
-Energy Statue: filler
-Krotite Armor: filler
-Golden Starfish: filler
-Golden Gear: filler
-Jelly Beacon: filler
-Jelly Costume: useful
-Jelly Plant: filler
-Mithalas Doll: filler
+Magic Soup: useful
+Mithalan dress: filler
 Mithalan Dress: filler
 Mithalas Banner: filler
+Mithalas banner: filler
+Mithalas Doll: filler
+Mithalas doll: filler
 Mithalas Pot: filler
+Mithalas pot: filler
+Mushroom x 2: useful
+Mutant costume: filler
 Mutant Costume: filler
-Baby Nautilus: useful
-Baby Piranha: useful
-Seed Bag: filler
-Song Plant Spore: filler
-Stone Head: filler
-Sun Key: useful
-Girl Costume: filler
+Nature form: progression
+Nature Form: progression
 Odd Container: filler
-Turtle Egg: filler
-Jelly Egg: filler
-Urchin Costume: filler
-Baby Walker: filler
-Transturtle Home Water: useful
-Transturtle Simon Says: progression
-Transturtle Arnassi Ruins: progression
-Rainbow Soup: filler
-Arcane Poultice: useful
-Special Bulb: filler
-Spirit Form: useful
-Special Cake: filler
-Swamp Cake: filler
-Cold Borscht: filler
-Tasty Cake: filler
-Spicy Roll: useful
-Healing Poultice: filler
-Hot Soup: progression
-Small Bone x 3: filler
+Odd container: filler
+Perogi: useful
+Plant Leaf x 2: useful
+Plant leaf x 2: useful
+Plant leaf x 3: useful
 Plant Leaf x 3: useful
-Bind Song: progression
+Plant Leaf: useful
+Plant leaf: useful
+Plump perogi: useful
+Plump Perogi: useful
+Poison loaf: filler
+Poison Loaf: filler
+Poison soup: filler
+Poison Soup: filler
+Rainbow mushroom: useful
+Rainbow Mushroom: useful
+Rainbow Soup: useful
+Rainbow soup: useful
+Red berry: useful
+Red Berry: useful
+Red Bulb x 2: useful
+Red bulb x 2: useful
+Rotten cake: filler
+Rotten Cake: filler
+Rotten loaf x 8: filler
+Rotten Loaf x 8: filler
+Rotten meat x 2: filler
 Rotten Meat x 2: filler
-Plant Leaf x 2: unknown
-Energy Form: unknown
-Leaf Poultice: unknown
-Rotten Cake: unknown
-Sun Form: unknown
-Leadership Roll: unknown
-Zuuna's Perogi: unknown
-Eel Oil x 2: unknown
-Hearty Soup: unknown
-Beast Form: unknown
-Leadership Roll x 2: unknown
-Glowing Egg: unknown
-Vedha Sea Crisp: unknown
-Rotten Meat: unknown
-Royal Soup: unknown
-Turtle Soup: unknown
-Glowing Egg x 2: unknown
-Door to the Cathedral opened: unknown
-Veggie Soup: unknown
-Veggie Cake: unknown
-Health Upgrade: unknown
-Long Life Soup: unknown
-Hand Roll: unknown
-Plant Leaf: unknown
-Sea Loaf x 2: unknown
-Fish Oil x 3: unknown
-Berry Ice Cream: unknown
-Leeching Poultice: unknown
-Transturtle Kelp Forest bottom left: unknown
-Fish Oil: unknown
-Spicy Soup: unknown
-Fish Meat x 2: unknown
-Sight Poultice: unknown
-Poison Soup: unknown
-Sea Cake: unknown
-Healing Poultice x 2: unknown
-Spicy Meat x 2: unknown
-Red Bulb x 2: unknown
-Small Bone x 2: unknown
+Rotten meat x 8: filler
+Rotten Meat x 8: filler
+Rotten meat: filler
+Rotten Meat: filler
+Royal Soup: useful
+Royal soup: useful
+Sea Cake: useful
+Sea cake: useful
+Sea loaf x 2: filler
+Sea Loaf x 2: filler
+Sea loaf: filler
+Sea Loaf: filler
+Seed bag: filler
+Seed Bag: filler
+Shark fin soup: useful
+Shark Fin Soup: useful
+Shield song: useful
+Sight Poultice: useful
+Sight poultice: useful
+Small Bone x 2: useful
+Small bone x 2: useful
+Small Bone x 3: useful
+Small bone x 3: useful
+Small egg x 2: useful
+Small Egg x 2: useful
+Small egg: useful
+Small Egg: useful
+Small tentacle x 2: useful
+Small Tentacle x 2: useful
+Song Plant Spore: filler
+Song plant spore: filler
+Special Bulb: useful
+Special bulb: useful
+Special Cake: useful
+Special cake: useful
+Spicy Meat x 2: useful
+Spicy meat x 2: useful
+Spicy roll: useful
+Spicy Roll: useful
+Spicy Soup: useful
+Spicy soup: useful
+Spider roll: useful
+Spider Roll: useful
+Spirit form: progression
+Spirit Form: progression
+Stone Head: filler
+Sun form: progression
+Sun Form: progression
+Sun Key: useful
+Swamp Cake: useful
+Swamp cake: useful
+Tasty Cake: useful
+Tasty cake: useful
+Tasty roll: useful
+Tasty Roll: useful
+Tooth: filler
+Tough cake: useful
+Tough Cake: useful
+Transturtle Abyss right: progression
+Transturtle Arnassi Ruins: progression
+Transturtle Final Boss: progression
+Transturtle Forest bottom left: progression
+Transturtle Home Waters: useful
+Transturtle Home Water: useful
+Transturtle Kelp Forest bottom left: progression
+Transturtle Open Water top right: progression
+Transturtle Open Waters top right: progression
+Transturtle Simon Says: progression
+Transturtle Veil top left: progression
+Transturtle Veil top right: progression
+Trident: filler
+Turtle Egg: filler
+Turtle egg: filler
+Turtle Soup: useful
+Turtle soup: useful
+Urchin Costume: filler
+Urchin costume: filler
+Vedha Sea Crisp: useful
+Vedha sea crisp: useful
+Vedha's Cure-All-All: useful
+Vedha's Cure-All: useful
+Veggie Cake: useful
+Veggie cake: useful
+Veggie ice cream: useful
+Veggie Ice Cream: useful
+Veggie Soup: useful
+Veggie soup: useful
+Volcano roll: useful
+Volcano Roll: useful
+Wok: useful
+Zuuna's Perogi: useful
+Zuuna's perogi: useful
+Body's tongue removed: progression
+Poison Trap: trap
+Blind Trap: trap
+Rainbow Trap: trap
+Mute Trap: trap
+Progressive Loaf: useful
+Progressive Soup: progression
+Progressive Poultice: useful
+Progressive Roll: useful
+Progressive Perogi: useful
+Progressive Ice Cream: useful


### PR DESCRIPTION
This fully reworks Aquaria. It has all variations of all items from AP0.5.1, AP0.6.0, AQ1.5.1 and AQ1.5.2. I think. Please let no one ever edit this god awful file again lmao.

It's intended that there is a duplicate of most names with capitalisation differences. It's intended that there are differences in progression / useful status of some items as they have changed classification since then.

If any item gets added after this, it can probably be considered BAD_NAME unless explicitly proven otherwise.