### PR TITLE
Adventure - Make Right Difficulty Switch Progression

### DIFF
--- a/worlds/Adventure/progression.txt
+++ b/worlds/Adventure/progression.txt
@@ -5,7 +5,7 @@ Freeincarnate: filler
 Left Difficulty Switch: filler
 Magnet: progression
 Revive Dragons: trap
-Right Difficulty Switch: filler
+Right Difficulty Switch: progression
 Slow Grundle: filler
 Slow Rhindle: filler
 Slow Yorgle: filler


### PR DESCRIPTION
The default classification for Right Difficulty Switch is filler, but depending on settings, its classification can be progression.  Specifically, if dragon_slay_check is true and difficulty_switch_b is option_hard_with_unlock_item, then it's progression.

https://github.com/ArchipelagoMW/Archipelago/blob/193faa00ce1d22209e7552643f968356a16ec139/worlds/adventure/__init__.py#L161