### PR TITLE
Aquaria - Classified new duplicate items and reclassified Sun Key

### DIFF
--- a/worlds/Aquaria/progression.txt
+++ b/worlds/Aquaria/progression.txt
@@ -39,7 +39,7 @@ Crab cake: useful
 Divine Soup: useful
 Divine soup: useful
 Door to the Cathedral opened: progression
-Dual Form: unknown
+Dual Form: progression
 Dual form: progression
 Dumbo Ice Cream: useful
 Dumbo ice cream: useful
@@ -185,7 +185,7 @@ Seed Bag: filler
 Seed bag: filler
 Shark Fin Soup: useful
 Shark fin soup: useful
-Shield Song: unknown
+Shield Song: useful
 Shield song: useful
 Sight Poultice: useful
 Sight poultice: useful
@@ -216,11 +216,11 @@ Spider roll: useful
 Spirit Form: progression
 Spirit form: progression
 Stone Head: filler
-Stone head: unknown
+Stone head: filler
 Sun Form: progression
 Sun Key: useful
 Sun form: progression
-Sun key: unknown
+Sun key: useful
 Swamp Cake: useful
 Swamp cake: useful
 Tasty Cake: useful
@@ -232,17 +232,17 @@ Tough Cake: useful
 Tough cake: useful
 Transturtle Abyss right: progression
 Transturtle Arnassi Ruins: progression
-Transturtle Arnassi ruins: unknown
+Transturtle Arnassi ruins: progression
 Transturtle Final Boss: progression
 Transturtle Forest bottom left: progression
 Transturtle Home Water: useful
 Transturtle Home Waters: useful
-Transturtle Home water: unknown
+Transturtle Home water: useful
 Transturtle Kelp Forest bottom left: progression
 Transturtle Open Water top right: progression
 Transturtle Open Waters top right: progression
 Transturtle Simon Says: progression
-Transturtle Simon says: unknown
+Transturtle Simon says: progression
 Transturtle Veil top left: progression
 Transturtle Veil top right: progression
 Trident: filler

--- a/worlds/Aquaria/progression.txt
+++ b/worlds/Aquaria/progression.txt
@@ -218,9 +218,9 @@ Spirit form: progression
 Stone Head: filler
 Stone head: filler
 Sun Form: progression
-Sun Key: useful
+Sun Key: filler
 Sun form: progression
-Sun key: useful
+Sun key: filler
 Swamp Cake: useful
 Swamp cake: useful
 Tasty Cake: useful


### PR DESCRIPTION
The bot has added a few new capitalization versions of item names since Palex did his major cleanup.  This sets the classification of the new names to the same thing as the other capitalization version.

I also reclassified Sun Key as filler as the developer will be reclassifying this in the apworld.
https://discord.com/channels/731205301247803413/1257452465272389687/1355231947713941564