### PR TITLE
DKC3 - Reclassify mcguffins

### DIFF
--- a/worlds/Donkey Kong Country 3/progression.txt
+++ b/worlds/Donkey Kong Country 3/progression.txt
@@ -4,7 +4,7 @@ Bear Coin: filler
 Bonus Coin: mcguffin
 Bowling Ball: progression
 DK Coin: mcguffin
-Donkey Kong: progression
+Donkey Kong: mcguffin
 Flupperius Petallus Pongus: progression
 Krematoa Cog: mcguffin
 Mirror: progression

--- a/worlds/Donkey Kong Country 3/progression.txt
+++ b/worlds/Donkey Kong Country 3/progression.txt
@@ -1,12 +1,12 @@
 1-Up Balloon: filler
-Banana Bird: progression
+Banana Bird: mcguffin
 Bear Coin: filler
-Bonus Coin: progression
+Bonus Coin: mcguffin
 Bowling Ball: progression
-DK Coin: progression
+DK Coin: mcguffin
 Donkey Kong: progression
 Flupperius Petallus Pongus: progression
-Krematoa Cog: progression
+Krematoa Cog: mcguffin
 Mirror: progression
 No. 6 Wrench: progression
 Present: progression


### PR DESCRIPTION
Banana Bird is definitely a mcguffin; they unlock no checks but are needed to goal if the goal is Banana Bird Hunt (15 by default).
Bonus Coins are needed to unlock levels (with checks) in the last world (15/level by default), and all of those levels need to be unlocked in order to goal if the goal is Knautilus.
Krematoa Cogs are only needed to reach Knautilus for that goal; 5 are needed.
DK Coins are used to get the Gyrocopter, which is progression and not needed for goal.  However, you need 10-41 of them to unlock it (30 by default).  That seems like it matches this bot's definition of a mcguffin.
Donkey Kong is not used at all.  It's just the "Victory" item on the goal location.

Progressive Boat Upgrade is the only non-mcguffin progression for DKC3.  All the other "progression" items in the data package are unimplemented.