### PR TITLE
SM64 - Reclassify 1Up Mushroom as filler

### DIFF
--- a/worlds/Super Mario 64/progression.txt
+++ b/worlds/Super Mario 64/progression.txt
@@ -1,4 +1,4 @@
-1Up Mushroom: useful
+1Up Mushroom: filler
 Backflip: progression
 Basement Key: progression
 Cannon Unlock BoB: progression


### PR DESCRIPTION
1up Mushroom is classified as filler in the apworld. https://github.com/ArchipelagoMW/Archipelago/blob/193faa00ce1d22209e7552643f968356a16ec139/worlds/sm64ex/Items.py#L22