### PR TITLE
OoA - Classify Master Keys as progression

### DIFF
--- a/worlds/The Legend of Zelda - Oracle of Ages/progression.txt
+++ b/worlds/The Legend of Zelda - Oracle of Ages/progression.txt
@@ -96,15 +96,15 @@ Like Like Ring: filler
 Lonely Peak: mcguffin
 Magic Oar: progression
 Maple's Ring: useful
-Master Key (Ancient Tomb): unknown
-Master Key (Crown Dungeon): unknown
-Master Key (Jabu-Jabu's Belly): unknown
-Master Key (Maku Path): unknown
-Master Key (Mermaid's Cave): unknown
-Master Key (Moonlit Grotto): unknown
-Master Key (Skull Dungeon): unknown
-Master Key (Spirit's Grave): unknown
-Master Key (Wing Dungeon): unknown
+Master Key (Ancient Tomb): progression
+Master Key (Crown Dungeon): progression
+Master Key (Jabu-Jabu's Belly): progression
+Master Key (Maku Path): progression
+Master Key (Mermaid's Cave): progression
+Master Key (Moonlit Grotto): progression
+Master Key (Skull Dungeon): progression
+Master Key (Spirit's Grave): progression
+Master Key (Wing Dungeon): progression
 Mermaid Key: progression
 Moblin Ring: filler
 Moosh's Flute: progression


### PR DESCRIPTION
Master Keys will effectively be having all of the small (and boss, depending on setting) keys, so the classification should match those.  The master key option has not been implemented yet, which is why nobody has encountered these to classify them yet.