### PR TITLE
Change Mystery Key classification to progression

### DIFF
--- a/worlds/Undertale/progression.txt
+++ b/worlds/Undertale/progression.txt
@@ -53,7 +53,7 @@ MERCY: useful
 Manly Bandanna: useful
 Mettaton Plush: progression
 Monster Candy: filler
-Mystery Key: filler
+Mystery Key: progression
 Nice Cream: filler
 Old Tutu: useful
 Papyrus Date: progression


### PR DESCRIPTION
The Mystery Key, featured in Undertale's beta apworld, is used to access the house directly to the right of Napstablook's house. Each of the 6 diary entries inside the locked house is a location. This means you need the Mystery Key to reach a few locations. That means its classification has to be progression.