### PR TITLE
The Minish Cap Change Rupees classification

### DIFF
--- a/worlds/The Minish Cap/progression.txt
+++ b/worlds/The Minish Cap/progression.txt
@@ -2,14 +2,14 @@
 10 Arrow Refill: filler
 10 Bomb Refill: filler
 100 Rupees: useful
-20 Rupees: useful
+20 Rupees: filler
 200 Rupees: useful
 30 Arrow Refill: filler
 30 Bomb Refill: filler
 5 Arrow Refill: filler
 5 Bomb Refill: filler
 5 Rupees: filler
-50 Rupees: useful
+50 Rupees: filler
 Big Key (CoF): progression
 Big Key (DWS): progression
 Big Key (FoW): progression


### PR DESCRIPTION
20 and 50 Rupees can be considered as filler. 100 and 200 Rupees can keep useful as there are checks behind pay wall, and you get enough of the 100 Rupees to buy them.