### PR TITLE
World Sense, Dream Wielder, Charm Notch to useful, Grubs and Eggs as mcguffin

### DIFF
--- a/worlds/Hollow Knight/progression.txt
+++ b/worlds/Hollow Knight/progression.txt
@@ -23,7 +23,7 @@ Boss_Geo-Gruz_Mother: filler
 Boss_Geo-Massive_Moss_Charger: filler
 Boss_Geo-Sanctum_Soul_Warrior: filler
 Boss_Geo-Vengefly_King: filler
-Charm_Notch: progression
+Charm_Notch: useful
 City_Crest: progression
 City_Storerooms_Stag: progression
 City_of_Tears_Map: filler
@@ -47,7 +47,7 @@ Double_Vessel_Fragment: useful
 Downslash: progression
 Dream_Gate: progression
 Dream_Nail: progression
-Dream_Wielder: progression
+Dream_Wielder: useful
 Dreamer: progression
 Dreamshield: progression
 Elegant_Key: progression
@@ -97,7 +97,7 @@ Greenpath_Stag: progression
 Grimmchild1: progression
 Grimmchild2: progression
 Grimmkin_Flame: progression
-Grub: progression
+Grub: mcguffin
 Grubberfly's_Elegy: useful
 Grubsong: useful
 Hallownest_Seal: useful
@@ -183,7 +183,7 @@ Queen_Fragment: progression
 Quick_Focus: useful
 Quick_Slash: useful
 Quill: filler
-Rancid_Egg: progression
+Rancid_Egg: mcguffin
 Resting_Grounds_Map: filler
 Resting_Grounds_Stag: progression
 Right_Crystal_Heart: progression
@@ -246,4 +246,4 @@ Whispering_Root-Queens_Gardens: useful
 Whispering_Root-Resting_Grounds: useful
 Whispering_Root-Spirits_Glade: useful
 Whispering_Root-Waterways: useful
-World_Sense: progression
+World_Sense: useful


### PR DESCRIPTION
Missed that Dream Wielder Charm was marked as progression still, since it was hiding among the Dream Nails

World Sense is a bit weird to be marked as progression because all it does is show world completion % and Hunter's Journal Enemies killed/required to be killed, really it should be filler, but there is some use for journal rando maybe? I do not know if the Rando defaults to showing the Enemies required without it. 

Marked both grubs and rancid eggs as mcguffin, since they dont do anything on their own, other than get you checks/money from Grubfather and Rancid Egg Shop checks(if enabled since default is disabled for Egg Shop)

Charm Notes is kind of a weird case to be progression, they are always strictly useful to have, and with insane Charm Notch Settings i could see them being progression since they would allow you to equip charms without overloading, they dont do anything on their own though. So useful is the more fitting category here.