### PR TITLE
Update pack rat

### DIFF
--- a/worlds/Autopelago/progression.txt
+++ b/worlds/Autopelago/progression.txt
@@ -288,7 +288,7 @@ Organic Apple Core: filler
 Overdue Library Book: filler
 Overly-Talkative Fairy in a Bottle: trap
 Oxford Comma: filler
-Pack Rat: progression
+Pack Rat: mcguffin
 Pack of Pickled Peppers: filler
 Packet of Ketchup: filler
 Pair of 3D Glasses: filler


### PR DESCRIPTION
Change Pack Rat from progression to macguffin. They don't add anything unless you have 5/25/49 of (them+other progression rats).