### PR TITLE
Pokemon Crystal: Fix TM08 to Progression

### DIFF
--- a/worlds/Pokemon Crystal/progression.txt
+++ b/worlds/Pokemon Crystal/progression.txt
@@ -199,7 +199,7 @@ TM06: useful
 TM07 Zap Cannon: useful
 TM07: useful
 TM08 Rock Smash: progression
-TM08: useful
+TM08: progression
 TM09 Psych Up: useful
 TM09: useful
 TM10 Hidden Power: useful


### PR DESCRIPTION
TM08 was marked as useful instead of progression
(note that TM08 is always Rock Smash)