### PR TITLE
Super Metroid/SMZ3 McGuffins

### DIFF
--- a/worlds/SMZ3/progression.txt
+++ b/worlds/SMZ3/progression.txt
@@ -62,7 +62,7 @@ CompassSW: filler
 CompassTH: filler
 CompassTR: filler
 CompassTT: filler
-ETank: progression
+ETank: mcguffin
 Ether: progression
 FiftyRupees: filler
 Firerod: progression
@@ -109,7 +109,7 @@ MapTH: filler
 MapTR: filler
 MapTT: filler
 Mirror: progression
-Missile: progression
+Missile: mcguffin
 MoonPearl: progression
 Morph: progression
 Mushroom: progression
@@ -118,7 +118,7 @@ OneHundredRupees: filler
 OneRupee: filler
 Plasma: progression
 Powder: progression
-PowerBomb: progression
+PowerBomb: mcguffin
 ProgressiveGlove: progression
 ProgressiveShield: progression
 ProgressiveSword: progression
@@ -126,7 +126,7 @@ ProgressiveTunic: useful
 Quake: progression
 RedBoomerang: useful
 RedContent: filler
-ReserveTank: progression
+ReserveTank: mcguffin
 ScrewAttack: progression
 Shovel: progression
 SilverArrows: useful
@@ -140,7 +140,7 @@ SpaceJump: progression
 Spazer: useful
 SpeedBooster: progression
 SpringBall: progression
-Super: progression
+Super: mcguffin
 TenArrows: filler
 ThreeBombs: filler
 ThreeHundredRupees: filler

--- a/worlds/Super Metroid/progression.txt
+++ b/worlds/Super Metroid/progression.txt
@@ -1,24 +1,24 @@
 Bomb: progression
 Charge Beam: progression
-Energy Tank: progression
+Energy Tank: mcguffin
 Generic: filler
 Grappling Beam: progression
 Gravity Suit: progression
 Hi-Jump Boots: progression
 Ice Beam: progression
-Missile: progression
+Missile: mcguffin
 Morph Ball: progression
 No Energy: filler
 Nothing: filler
 Plasma Beam: progression
-Power Bomb: progression
-Reserve Tank: progression
+Power Bomb: mcguffin
+Reserve Tank: mcguffin
 Screw Attack: progression
 Space Jump: progression
 Spazer: progression
 Speed Booster: progression
 Spring Ball: progression
-Super Missile: progression
+Super Missile: mcguffin
 Varia Suit: progression
 Wave Beam: progression
 X-Ray Scope: progression


### PR DESCRIPTION
Energy Tanks, Missiles, Power Bombs, Reserve Tanks, and Super Missiles are not important enough by themselves to be categorized/treated as full Progression items. This PR marks them as McGuffins so that AP Alert bot users won't be constantly and unnecessarily notified about receiving additional ammo/health capacity.