### PR TITLE
Majora's Mask updates

### DIFF
--- a/worlds/Majora's Mask Recompiled/progression.txt
+++ b/worlds/Majora's Mask Recompiled/progression.txt
@@ -1,15 +1,17 @@
 All-Night Mask: progression
 Blast Mask: progression
 Blue Rupee: filler
-Bombchu (10): useful
+Bombchu (1): progression
+Bombchu (5): progression
+Bombchu (10): progression
 Bomber's Notebook: useful
-Boss Key (Great Bay): mcguffin
-Boss Key (Snowhead): mcguffin
-Boss Key (Stone Tower): mcguffin
-Boss Key (Woodfall): mcguffin
+Boss Key (Great Bay): progression
+Boss Key (Snowhead): progression
+Boss Key (Stone Tower): progression
+Boss Key (Woodfall): progression
 Bottle of Chateau Romani: progression
 Bottle of Milk: progression
-Bottle of Red Potion: useful
+Bottle of Red Potion: progression
 Bottle: progression
 Bremen Mask: progression
 Bundle of 30 Arrows: filler
@@ -31,7 +33,7 @@ Dungeon Map (Stone Tower): useful
 Dungeon Map (Woodfall): useful
 Elegy of Emptiness: progression
 Epona's Song: progression
-Fierce Deity's Mask: useful
+Fierce Deity's Mask: progression
 Fire Arrow: progression
 Garo Mask: progression
 Giant's Mask: progression
@@ -87,20 +89,20 @@ Red Rupee: filler
 Romani Mask: progression
 Romani Ranch Map: useful
 Room Key: progression
-Silver Rupee: filler
-Small Key (Great Bay): mcguffin
-Small Key (Snowhead): mcguffin
-Small Key (Stone Tower): mcguffin
-Small Key (Woodfall): mcguffin
+Silver Rupee: useful
+Small Key (Great Bay): progression
+Small Key (Snowhead): progression
+Small Key (Stone Tower): progression
+Small Key (Woodfall): progression
 Snowhead Map: useful
 Sonata of Awakening: progression
 Song of Healing: progression
-Song of Soaring: useful
+Song of Soaring: progression
 Song of Storms: progression
 Song of Time: progression
 Stone Mask: progression
 Stone Tower Map: useful
-Stray Fairy (Clock Town): mcguffin
+Stray Fairy (Clock Town): progression
 Stray Fairy (Great Bay): mcguffin
 Stray Fairy (Snowhead): mcguffin
 Stray Fairy (Stone Tower): mcguffin


### PR DESCRIPTION
Bombchus are an ambiguous one.  The apworld code registers those three quantities of progression class bombchus, and the baby/easy logic code does use them for logic, but the baby/easy logic setting is not available in the latest version of the apworld, and it doesn't look like the latest version creates any of those bombchu items at all.  (It creates Progressive Bombchu Bag instead.)  Including them will probably only affect people playing on older versions of the apworld, or if baby logic is ever turned back on, but these changes should cover those situations.

I don't see any reason for boss keys and small keys to be mcguffins rather than progression.  There are only one of each boss key, and the first small key for each dungeon can logically unlock one or more checks.

Bottle of Red Potion is progression for the same reason all the other bottles are (gives access to an empty bottle which is needed for some checks), as well as being logical progression for its own unique checks.

Fierce Deity's Mask is progression because it gives access to a sword.  (Starting swordless is an option.)  (It would likely be useful+progression if the apworld did dual classification.)

Silver Rupee is marked useful in the apworld.  The delineation in the apworld for filler/useful is between purple (50) and silver (100), but this file previously had it between silver (100) and gold (200).  It's arbitrary, as useful generally is, but we might as well follow the apworld.

I was surprised to see Song of Soaring as progression in the apworld, since it's just the ability to fast travel to places you've already been, but looking at the logic, I was reminded that it can be needed to keep hot water hot during a fetch quest.  Without some way to travel fast (which has other alternatives to Song of Soaring), the water will cool down before you reach your destination.

While all the rest of the Stray Fairies can be considered mcguffins because you need all 15 of a certain type to unlock their check, there is only one Stray Fairy (Clock Town), and it has a corresponding check unlocked by only having that one item.